### PR TITLE
Fixes ‘directives’ heading so that ‘settings’ can be a subheading of it.

### DIFF
--- a/guides/language/directives.rst
+++ b/guides/language/directives.rst
@@ -1,5 +1,5 @@
 Directives
-----------
+++++++++++
 
 Directives are Gyro language extensions that add functionality to the base language. Directives begin with
 the ``@`` symbol, for example, the line ``@plugin: 'gyro:gyro-aws-provider:0.15-SNAPSHOT'`` in the "Test Your Installation"


### PR DESCRIPTION
Fixes #22 