### PR TITLE
Fix search on gyro.dev

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -38,7 +38,6 @@ BUILD_DIRECTORY=`pwd`/$1
 cd $BUILD_DIRECTORY
 sh ./generate-provider-docs.sh
 make html
-rm -rf "_build/html/_sources" #remove unnecessary files
 
 # If this Travis job is not a pull request, 
 # assume it is a merge and deploy to S3


### PR DESCRIPTION
Fixes #25 

The search used by sphinx relies on `_build/html/_sources` folder which was being removed.